### PR TITLE
Fix bug when no excludes are specified with -e arg

### DIFF
--- a/src/name-constraints-encoder.py
+++ b/src/name-constraints-encoder.py
@@ -45,7 +45,7 @@ def main():
     args = parser.parse_args()
 
     permitted_subtrees = []
-    excluded_subtrees = []
+    excluded_subtrees = None
 
     if (not args.Permitted) and (not args.Excluded):
         raise ValueError(
@@ -60,6 +60,7 @@ def main():
 
     # Excluded Subtrees will override Permitted Subtrees
     if args.Excluded:
+        excluded_subtrees = []
         for exclude in args.Excluded.split(","):
             excluded_subtrees.append(DNSName(exclude))
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws-samples/aws-private-ca-enforce-dns-name-constraints/issues/4

*Description of changes:*
Initialize excluded_subtrees as None. If args.Excluded exists, excluded_subtrees becomes an empty array ready to take the strings parsed from args.Excluded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
